### PR TITLE
Bumps all libraries/dependencies versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val `jam-parser` = project
     name := "jam-parser",
     version := "0.0.1",
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "fastparse" % "1.0.0"
+      "com.lihaoyi" %% "fastparse" % "2.1.0"
     )
   )
 

--- a/jam-parser/src/main/scala/jam/parser/YamlParser.scala
+++ b/jam-parser/src/main/scala/jam/parser/YamlParser.scala
@@ -19,7 +19,7 @@ object YamlParser {
 
   def strChars[_: P]: P[Unit] = P(CharsWhile(stringChars))
 
-  def digits[_: P]: P[Unit] = P(CharIn("\\+", "\\-").? ~ CharsWhileIn("0123456789"))
+  def digits[_: P]: P[Unit] = P(CharIn("+\\-").? ~ CharsWhileIn("0123456789"))
 
   def decimals[_: P]: P[Unit] = P(((digits ~ "." ~ digits) | digits) ~ (CharIn("eE") ~ digits).?)
 

--- a/jam-parser/src/main/scala/jam/parser/YamlParser.scala
+++ b/jam-parser/src/main/scala/jam/parser/YamlParser.scala
@@ -13,7 +13,7 @@ object YamlParser {
 
   def hexDigit[_: P]: P[Unit] = P(CharIn("0-9", "a-f", "A-F"))
 
-  def unicodeEscape[_: P]: P[Unit] = P("u" ~ hexDigit ~ hexDigit ~ hexDigit ~ hexDigit)
+  def unicodeEscape[_: P]: P[Unit] = P("u" ~ hexDigit.rep(exactly = 4) ~ End)
 
   def escape[_: P]: P[Unit] = P("\\" ~ (CharIn("\"/\\bfnrt") | unicodeEscape))
 
@@ -81,10 +81,10 @@ object YamlParser {
       } yield (s, b)
     }
 
-  def start[_: P] = P(Start ~ CharsWhileIn(" \r\n").rep.?)
+  def start[_: P]: P[Unit] = P(Start ~ CharsWhileIn(" \r\n").rep.?)
 
-  def end[_: P] = P(CharsWhileIn(" \r\n").rep.? ~ End)
+  def end[_: P]: P[Unit] = P(CharsWhileIn(" \r\n").rep.? ~ End)
 
-  def yaml[_: P] = start ~ root()
+  def yaml[_: P]: P[Yaml] = start ~ root()
 
 }

--- a/jam-parser/src/main/scala/jam/parser/YamlParser.scala
+++ b/jam-parser/src/main/scala/jam/parser/YamlParser.scala
@@ -1,60 +1,60 @@
 package jam.parser
 
-import fastparse.all
+import fastparse._
+import NoWhitespace._
 import jam.Yaml
 import jam.Yaml._
 
 import scala.collection.immutable.ListMap
 
 object YamlParser {
-  import all._
 
-  val stringChars: Char => Boolean = !(":\n\"\\").contains(_: Char)
+  val stringChars: Char => Boolean = !":\n\"\\".contains(_: Char)
 
-  val hexDigit = P(CharIn('0' to '9', 'a' to 'f', 'A' to 'F'))
+  def hexDigit[_: P]: P[Unit] = P(CharIn("0-9", "a-f", "A-F"))
 
-  val unicodeEscape = P("u" ~ hexDigit ~ hexDigit ~ hexDigit ~ hexDigit)
+  def unicodeEscape[_: P]: P[Unit] = P("u" ~ hexDigit ~ hexDigit ~ hexDigit ~ hexDigit)
 
-  val escape = P("\\" ~ (CharIn("\"/\\bfnrt") | unicodeEscape))
+  def escape[_: P]: P[Unit] = P("\\" ~ (CharIn("\"/\\bfnrt") | unicodeEscape))
 
-  val strChars = P(CharsWhile(stringChars))
+  def strChars[_: P]: P[Unit] = P(CharsWhile(stringChars))
 
-  val digits = P(CharIn("+-").? ~ CharsWhileIn("0123456789"))
+  def digits[_: P]: P[Unit] = P(CharIn("\\+", "\\-").? ~ CharsWhileIn("0123456789"))
 
-  val decimals = P(((digits ~ "." ~ digits) | digits) ~ (CharIn("eE") ~ digits).?)
+  def decimals[_: P]: P[Unit] = P(((digits ~ "." ~ digits) | digits) ~ (CharIn("eE") ~ digits).?)
 
-  val strings = P("\"".? ~/ (strChars | escape).rep.! ~ "\"".?).map(x => Yaml.YString(x))
+  def strings[_: P]: P[YString] = P("\"".? ~/ (strChars | escape).rep.! ~ "\"".?).map(x => Yaml.YString(x))
 
-  val bigDecimals = decimals.!.map(x => Yaml.YBigDecimal(BigDecimal(x)))
+  def bigDecimals[_: P]: P[YBigDecimal] = decimals.!.map(x => Yaml.YBigDecimal(BigDecimal(x)))
 
-  val True = P("True" | "true").!.map(_ => Yaml.YTrue)
+  def True[_: P]: P[Yaml.YTrue.type] = P("True" | "true").!.map(_ => Yaml.YTrue)
 
-  val False = P("False" | "false").!.map(_ => Yaml.YFalse)
+  def False[_: P]: P[Yaml.YFalse.type] = P("False" | "false").!.map(_ => Yaml.YFalse)
 
-  val primitives = P(True | False | bigDecimals | strings).log()
+  def primitives[_: P]: P[Yaml] = P(True | False | bigDecimals | strings)
 
-  val space = P(CharsWhileIn(" \r").?)
+  def space[_: P]: P[Unit] = P(CharsWhileIn(" \r").?)
 
-  val keys = P((strChars | escape).rep.! ~/ ":").log()
+  def keys[_: P]: P[String] = P((strChars | escape).rep.! ~/ ":")
 
-  val nested = P("\n" ~ " ".rep.!).log()
+  def nested[_: P]: P[String] = P("\n" ~ " ".rep.!)
 
-  val emptyArray = "[]".!.map(_ => YArray(Vector.empty))
+  def emptyArray[_: P]: P[YArray] = "[]".!.map(_ => YArray(Vector.empty))
 
-  def root(s: String = ""): all.Parser[Yaml] =
+  def root[_: P](s: String = ""): P[Yaml] =
     P {
       for {
         a <- &("- ").!.?
         b <- a match {
           case None =>
-            objectRec.rep(sep = (("\n" + s) ~ !end).~/).map(x => YMap(ListMap(x: _*)))
+            objectRec.rep(sep = ("\n" + s) ~ !end).map(x => YMap(ListMap(x: _*)))
           case Some(_) =>
-            ("- " ~/ collectionRec(s + "  ")).rep(sep = (("\n" + s) ~ !end).~/).map(x => YArray(x.toVector))
+            ("- " ~/ collectionRec(s + "  ")).rep(sep = ("\n" + s) ~ !end).map(x => YArray(x.toVector))
         }
       } yield b
-    }.log()
+    }
 
-  def collectionRec(s: String = ""): all.Parser[Yaml] =
+  def collectionRec[_: P](s: String = ""): P[Yaml] =
     P {
       for {
         a <- &(keys).!.?
@@ -62,12 +62,12 @@ object YamlParser {
           case None =>
             primitives
           case Some(_) =>
-            objectRec.rep(sep = (("\n" + s) ~ !"- ").~/).map(x => YMap(ListMap(x: _*)))
+            objectRec.rep(sep = ("\n" + s) ~ !"- ").map(x => YMap(ListMap(x: _*)))
         }
       } yield b
-    }.log()
+    }
 
-  val objectRec: all.Parser[(String, Yaml)] =
+  def objectRec[_: P]: P[(String, Yaml)] =
     P {
       for {
         a <- keys ~ space ~ nested.?
@@ -79,12 +79,12 @@ object YamlParser {
             root(n)
         }
       } yield (s, b)
-    }.log()
+    }
 
-  val start = P(Start ~ CharsWhileIn(" \r\n").rep.?)
+  def start[_: P] = P(Start ~ CharsWhileIn(" \r\n").rep.?)
 
-  val end = P(CharsWhileIn(" \r\n").rep.? ~ End)
+  def end[_: P] = P(CharsWhileIn(" \r\n").rep.? ~ End)
 
-  val yaml = start ~ root()
+  def yaml[_: P] = start ~ root()
 
 }

--- a/jam-parser/src/main/scala/jam/printer/YamlPrinter.scala
+++ b/jam-parser/src/main/scala/jam/printer/YamlPrinter.scala
@@ -1,11 +1,11 @@
-package jam.parser
+package jam.printer
 
 import jam.Yaml
 
 object YamlPrinter {
   import Yaml._
 
-  def printYMap(
+  private[printer] def printYMap(
       yMap: YMap,
       builder: StringBuilder,
       indent: Int,
@@ -21,9 +21,9 @@ object YamlPrinter {
     }
   }
 
-  def printYArray(yArray: YArray, builder: StringBuilder, indent: Int): scala.StringBuilder =
+  private[printer] def printYArray(yArray: YArray, builder: StringBuilder, indent: Int): scala.StringBuilder =
     yArray.v match {
-      case vec @ (a +: as) =>
+      case vec @ _ +: _ =>
         vec.foldLeft(builder) {
           case (b, yaml) =>
             b.append("\n")
@@ -38,7 +38,7 @@ object YamlPrinter {
 
     }
 
-  def printPrimitives(builder: StringBuilder, space: Int = 0): PartialFunction[Yaml, StringBuilder] = {
+  private[printer] def printPrimitives(builder: StringBuilder, space: Int = 0): PartialFunction[Yaml, StringBuilder] = {
     case YNull  => builder.append(s"${" " * space}null")
     case YFalse => builder.append(s"${" " * space}false")
     case YTrue  => builder.append(s"${" " * space}true")

--- a/jam-parser/src/test/scala/jam/parser/Generators.scala
+++ b/jam-parser/src/test/scala/jam/parser/Generators.scala
@@ -6,41 +6,41 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 trait Generators extends GeneratorDrivenPropertyChecks {
 
-  val arbitraryString = Arbitrary.arbString
+  val arbitraryString: Arbitrary[String] = Arbitrary.arbString
 
-  val arbitraryDouble = Arbitrary.arbDouble
+  val arbitraryDouble: Arbitrary[Double] = Arbitrary.arbDouble
 
-  val arbitraryFloat = Arbitrary.arbFloat
+  val arbitraryFloat: Arbitrary[Float] = Arbitrary.arbFloat
 
-  val arbitraryBigInt = Arbitrary.arbBigInt
+  val arbitraryBigInt: Arbitrary[BigInt] = Arbitrary.arbBigInt
 
-  val arbitraryBigDecimal = Arbitrary.arbBigDecimal
+  val arbitraryBigDecimal: Arbitrary[BigDecimal] = Arbitrary.arbBigDecimal
 
-  val stringGen =
+  val stringGen: Gen[String] =
     listOf(Gen.frequency((5, Gen.alphaNumStr), (3, " "))).map(_.mkString)
 
-  val negativeIntGen = Gen.chooseNum[Int](-2147483648, -1)
+  val negativeIntGen: Gen[Int] = Gen.chooseNum[Int](-2147483648, -1)
 
-  val positiveIntGen = Gen.chooseNum[Int](0, 2147483647)
+  val positiveIntGen: Gen[Int] = Gen.chooseNum[Int](0, 2147483647)
 
-  val negativeLongGen = Gen.choose[Long](-9223372036854775808L, -1L)
+  val negativeLongGen: Gen[Long] = Gen.choose[Long](-9223372036854775808L, -1L)
 
   val positiveLongGen: Gen[Long] = Gen.chooseNum[Long](0L, 9223372036854775807L)
 
-  val positiveFloatGen = arbitraryFloat.arbitrary.filter(_ >= 0D)
+  val positiveFloatGen: Gen[Float] = arbitraryFloat.arbitrary.filter(_ >= 0D)
 
-  val negativeFloatGen = arbitraryFloat.arbitrary.filter(_ < 0D)
+  val negativeFloatGen: Gen[Float] = arbitraryFloat.arbitrary.filter(_ < 0D)
 
-  val positiveDoubleGen = arbitraryDouble.arbitrary.filter(_ >= 0D)
+  val positiveDoubleGen: Gen[Double] = arbitraryDouble.arbitrary.filter(_ >= 0D)
 
-  val negativeDoubleGen = arbitraryDouble.arbitrary.filter(_ < 0D)
+  val negativeDoubleGen: Gen[Double] = arbitraryDouble.arbitrary.filter(_ < 0D)
 
-  val positiveBigDecimalGen = arbitraryBigDecimal.arbitrary.filter(_ >= 0)
+  val positiveBigDecimalGen: Gen[BigDecimal] = arbitraryBigDecimal.arbitrary.filter(_ >= 0)
 
-  val negativeBigDecimalGen = arbitraryBigDecimal.arbitrary.filter(_ < 0)
+  val negativeBigDecimalGen: Gen[BigDecimal] = arbitraryBigDecimal.arbitrary.filter(_ < 0)
 
-  val positiveBigIntGen = arbitraryBigInt.arbitrary.filter(_ >= 0)
+  val positiveBigIntGen: Gen[BigInt] = arbitraryBigInt.arbitrary.filter(_ >= 0)
 
-  val negativeBigIntGen = arbitraryBigInt.arbitrary.filter(_ < 0)
+  val negativeBigIntGen: Gen[BigInt] = arbitraryBigInt.arbitrary.filter(_ < 0)
 
 }

--- a/jam-parser/src/test/scala/jam/parser/YamlParserTest.scala
+++ b/jam-parser/src/test/scala/jam/parser/YamlParserTest.scala
@@ -1,6 +1,6 @@
 package jam.parser
 
-import fastparse.core.Parsed
+import fastparse._
 import jam.Yaml._
 import org.scalatest.{ Inside, MustMatchers, WordSpec }
 
@@ -9,14 +9,12 @@ import scala.io.Source
 
 class YamlParserTest extends WordSpec with MustMatchers with Inside with Generators {
 
-  val parser = YamlParser
-
   "YamlParser" should {
 
     "parse a string" in {
 
       forAll(stringGen) { s: String =>
-        inside(parser.strings.parse(s)) {
+        inside(parse(s, YamlParser.strings(_))) {
           case Parsed.Success(v, _) =>
             v mustBe YString(s)
         }
@@ -25,7 +23,7 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
 
     "parse a positive BigDecimal" in {
       forAll(positiveBigDecimalGen) { s: BigDecimal =>
-        inside(parser.bigDecimals.parse(s.toString)) {
+        inside(parse(s.toString, YamlParser.bigDecimals(_))) {
           case Parsed.Success(v, _) =>
             v mustBe YBigDecimal(s)
         }
@@ -34,7 +32,7 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
 
     "parse a negative BigDecimal" in {
       forAll(negativeBigDecimalGen) { s: BigDecimal =>
-        inside(parser.bigDecimals.parse(s.toString)) {
+        inside(parse(s.toString, YamlParser.bigDecimals(_))) {
           case Parsed.Success(v, _) =>
             v mustBe YBigDecimal(s)
         }
@@ -42,24 +40,24 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
     }
 
     "parse a true" in {
-      inside(parser.True.parse("true")) {
+      inside(parse("true", YamlParser.True(_))) {
         case Parsed.Success(v, _) =>
           v mustBe YTrue
       }
 
-      inside(parser.True.parse("True")) {
+      inside(parse("True", YamlParser.True(_))) {
         case Parsed.Success(v, _) =>
           v mustBe YTrue
       }
     }
 
     "parse a false" in {
-      inside(parser.False.parse("false")) {
+      inside(parse("false", YamlParser.False(_))) {
         case Parsed.Success(v, _) =>
           v mustBe YFalse
       }
 
-      inside(parser.False.parse("False")) {
+      inside(parse("False", YamlParser.False(_))) {
         case Parsed.Success(v, _) =>
           v mustBe YFalse
       }
@@ -68,7 +66,7 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
     "parse a simple object" in {
       val value = getYaml("/simple.yaml")
 
-      inside(parser.yaml.parse(value)) {
+      inside(parse(value, YamlParser.yaml(_))) {
         case Parsed.Success(v, _) =>
           v mustBe YMap(
             ListMap(
@@ -83,7 +81,7 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
     "parse a nested object" in {
       val value = getYaml("/nestedObject.yaml")
 
-      inside(parser.yaml.parse(value)) {
+      inside(parse(value, YamlParser.yaml(_))) {
         case Parsed.Success(v, _) =>
           v mustBe YMap(
             ListMap(
@@ -108,7 +106,7 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
     "parse a nested array object" in {
       val value = getYaml("/nestedArrays.yaml")
 
-      inside(parser.yaml.parse(value)) {
+      inside(parse(value, YamlParser.yaml(_))) {
         case Parsed.Success(v, _) =>
           v mustBe YMap(
             ListMap(
@@ -211,7 +209,7 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
     }
   }
 
-  def getYaml(path: String) =
+  def getYaml(path: String): String =
     Source
       .fromInputStream(this.getClass.getResourceAsStream(path))
       .mkString

--- a/jam-parser/src/test/scala/jam/parser/YamlParserTest.scala
+++ b/jam-parser/src/test/scala/jam/parser/YamlParserTest.scala
@@ -12,7 +12,6 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
   "YamlParser" should {
 
     "parse a string" in {
-
       forAll(stringGen) { s: String =>
         inside(parse(s, YamlParser.strings(_))) {
           case Parsed.Success(v, _) =>
@@ -37,6 +36,25 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
             v mustBe YBigDecimal(s)
         }
       }
+    }
+
+    "parse a valid unicode sequence" in {
+      parse("uabcd", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
+      parse("uABC4", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
+      parse("uA9bF", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
+      parse("u1234", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
+    }
+
+    "fail parsing an invalid character range in an unicode sequence" in {
+      parse("ufgej", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Failure]
+    }
+
+    "fail parsing an invalid unicode sequence (length)" in {
+      parse("uaaaab", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Failure]
+    }
+
+    "fail parsing an invalid unicode sequence (invalid prefix)" in {
+      parse("zaaaab", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Failure]
     }
 
     "parse a true" in {

--- a/jam-parser/src/test/scala/jam/parser/YamlParserTest.scala
+++ b/jam-parser/src/test/scala/jam/parser/YamlParserTest.scala
@@ -38,11 +38,66 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
       }
     }
 
+    "parse a valid hex digit" in {
+      parse("f", YamlParser.hexDigit(_)) mustBe a[Parsed.Success[_]]
+      parse("F", YamlParser.hexDigit(_)) mustBe a[Parsed.Success[_]]
+      parse("9", YamlParser.hexDigit(_)) mustBe a[Parsed.Success[_]]
+    }
+
+    "parse an invalid hex digit" in {
+      parse("J", YamlParser.hexDigit(_)) mustBe a[Parsed.Failure]
+      parse("Z", YamlParser.hexDigit(_)) mustBe a[Parsed.Failure]
+    }
+
     "parse a valid unicode sequence" in {
       parse("uabcd", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
       parse("uABC4", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
       parse("uA9bF", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
       parse("u1234", YamlParser.unicodeEscape(_)) mustBe a[Parsed.Success[_]]
+    }
+
+    "parse a valid escape character" in {
+      parse("\\n", YamlParser.escape(_)) mustBe a[Parsed.Success[_]]
+      parse("\\b", YamlParser.escape(_)) mustBe a[Parsed.Success[_]]
+      parse("\\r", YamlParser.escape(_)) mustBe a[Parsed.Success[_]]
+    }
+
+    "parse an invalid escape character" in {
+      parse("\\w", YamlParser.escape(_)) mustBe a[Parsed.Failure]
+    }
+
+    "parse a valid character" in {
+      parse("z", YamlParser.strChars(_)) mustBe a[Parsed.Success[_]]
+      parse("5", YamlParser.strChars(_)) mustBe a[Parsed.Success[_]]
+      parse("?", YamlParser.strChars(_)) mustBe a[Parsed.Success[_]]
+    }
+
+    "parse an invalid character" in {
+      parse(":", YamlParser.strChars(_)) mustBe a[Parsed.Failure]
+      parse("\\n", YamlParser.strChars(_)) mustBe a[Parsed.Failure]
+    }
+
+    "parse a valid number" in {
+      parse("-24535345345", YamlParser.digits(_)) mustBe a[Parsed.Success[_]]
+      parse("+500", YamlParser.digits(_)) mustBe a[Parsed.Success[_]]
+      parse("679", YamlParser.digits(_)) mustBe a[Parsed.Success[_]]
+    }
+
+    "parse an invalid number" in {
+      parse("-abc", YamlParser.digits(_)) mustBe a[Parsed.Failure]
+    }
+
+    "parse a valid decimal number" in {
+      parse("-2.22", YamlParser.decimals(_)) mustBe a[Parsed.Success[_]]
+      parse("+437.023424", YamlParser.decimals(_)) mustBe a[Parsed.Success[_]]
+      parse("1.001", YamlParser.decimals(_)) mustBe a[Parsed.Success[_]]
+      parse("1.001e-06", YamlParser.decimals(_)) mustBe a[Parsed.Success[_]]
+      parse("1.001e+06", YamlParser.decimals(_)) mustBe a[Parsed.Success[_]]
+      parse("1.001e06", YamlParser.decimals(_)) mustBe a[Parsed.Success[_]]
+    }
+
+    "parse an invalid decimal number" in {
+      parse("--5432312312", YamlParser.decimals(_)) mustBe a[Parsed.Failure]
     }
 
     "fail parsing an invalid character range in an unicode sequence" in {
@@ -162,68 +217,6 @@ class YamlParserTest extends WordSpec with MustMatchers with Inside with Generat
             )
           )
       }
-    }
-
-    "generate yaml" in {
-      val sb = new StringBuilder()
-      val yaml = YMap(
-        ListMap(
-          "info" -> YMap(
-            ListMap(
-              "address"   -> YString("none"),
-              "telephone" -> YString("12345"),
-              "info" -> YMap(
-                ListMap(
-                  "address"   -> YString("none"),
-                  "telephone" -> YString("12345")
-                )
-              )
-            )
-          ),
-          "test" -> YBigDecimal(0)
-        )
-      )
-      val value = YamlPrinter.printYaml(yaml, sb).toString()
-      value mustBe getYaml("/nestedObject.yaml")
-
-      val yaml2 = YMap(
-        ListMap(
-          "numbers" -> YArray(
-            Vector(YBigDecimal(-1), YBigDecimal(2), YBigDecimal(3))
-          ),
-          "empty" -> YArray(Vector()),
-          "details" -> YArray(
-            Vector(
-              YMap(
-                ListMap(
-                  "count"     -> YBigDecimal(-1),
-                  "something" -> YTrue,
-                  "array" -> YArray(
-                    Vector(
-                      YMap(
-                        ListMap(
-                          "count" -> YBigDecimal(1),
-                          "name"  -> YString("james"),
-                          "object" -> YMap(
-                            ListMap(
-                              "kind"   -> YString("nothing to see"),
-                              "double" -> YBigDecimal(-0.001)
-                            )
-                          )
-                        )
-                      )
-                    )
-                  )
-                )
-              ),
-              YMap(ListMap("count" -> YBigDecimal(2)))
-            )
-          )
-        )
-      )
-      val sb2    = new StringBuilder()
-      val value2 = YamlPrinter.printYaml(yaml2, sb2).toString()
-      value2 mustBe getYaml("/nestedArrays.yaml")
     }
   }
 

--- a/jam-parser/src/test/scala/jam/printer/YamlPrinterTest.scala
+++ b/jam-parser/src/test/scala/jam/printer/YamlPrinterTest.scala
@@ -1,0 +1,79 @@
+package jam.printer
+import jam.Yaml._
+import org.scalatest.{ MustMatchers, WordSpec }
+
+import scala.collection.immutable.ListMap
+import scala.io.Source
+
+class YamlPrinterTest extends WordSpec with MustMatchers {
+
+  "YamlPrinter" should {
+    "generate yaml" in {
+      val sb = new StringBuilder()
+      val yaml = YMap(
+        ListMap(
+          "info" -> YMap(
+            ListMap(
+              "address"   -> YString("none"),
+              "telephone" -> YString("12345"),
+              "info" -> YMap(
+                ListMap(
+                  "address"   -> YString("none"),
+                  "telephone" -> YString("12345")
+                )
+              )
+            )
+          ),
+          "test" -> YBigDecimal(0)
+        )
+      )
+      val value = YamlPrinter.printYaml(yaml, sb).toString()
+      value mustBe getYaml("/nestedObject.yaml")
+
+      val yaml2 = YMap(
+        ListMap(
+          "numbers" -> YArray(
+            Vector(YBigDecimal(-1), YBigDecimal(2), YBigDecimal(3))
+          ),
+          "empty" -> YArray(Vector()),
+          "details" -> YArray(
+            Vector(
+              YMap(
+                ListMap(
+                  "count"     -> YBigDecimal(-1),
+                  "something" -> YTrue,
+                  "array" -> YArray(
+                    Vector(
+                      YMap(
+                        ListMap(
+                          "count" -> YBigDecimal(1),
+                          "name"  -> YString("james"),
+                          "object" -> YMap(
+                            ListMap(
+                              "kind"   -> YString("nothing to see"),
+                              "double" -> YBigDecimal(-0.001)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              ),
+              YMap(ListMap("count" -> YBigDecimal(2)))
+            )
+          )
+        )
+      )
+      val sb2    = new StringBuilder()
+      val value2 = YamlPrinter.printYaml(yaml2, sb2).toString()
+      value2 mustBe getYaml("/nestedArrays.yaml")
+    }
+  }
+
+  def getYaml(path: String): String =
+    Source
+      .fromInputStream(this.getClass.getResourceAsStream(path))
+      .mkString
+
+}

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -4,13 +4,13 @@ import Keys._
 object Common {
 
   lazy val commonSettings = Seq(
-    organization := "leandrob13",
-    scalaVersion := "2.12.4",
+    organization := "co.s4n",
+    scalaVersion := "2.12.7",
     fork := true,
     fork in test := true,
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.3" % Test,
-      "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
+      "org.scalatest"         %% "scalatest"              % "3.0.5"     % Test,
+      "org.scalacheck"        %% "scalacheck"             % "1.14.0"    % Test
     ),
     scalacOptions ++= Seq(
       "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.2.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC14")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M9")
 
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")


### PR DESCRIPTION
- Bumps Fastparse to 2.1.0. This change is binary breaking with the previous implementation, so I had to rewrite the parsers to fit the new fastparse syntax.
- Bumps sbt version to 1.2.7.
- Bumps Scala version to 2.12.7.
- Bumps Coursier version to 1.1.0-M9.
- Bumps Scalafmt version to 1.15.
- Adds sbt-scoverage plugin in its latest version.
- Fixes unit tests based on the fastparse breaking change.